### PR TITLE
Update expected URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - Unreleased
+## [1.1.0] - 2023-05-16
 ### Changed
 - Upgrade Go to 1.19.
+- Update expected URLs according to the Astarte 1.1 docker-compose file.
 
 ## [1.0.0] - 2023-05-16
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ with
 ./wait-for-astarte-docker-compose
 ```
 
-The program will return `0` when all the services start succesfully or `1` if it there is a timeout.
+The program will return `0` when all services API start succesfully or `1` if it there is a timeout.
 The default timeout is 300 seconds, a different timeout can be specified with the `-t` flag.
 
-The program expects all Astarte services to be served on the default ports specified in the
+The program expects all Astarte services to be exposed on the default host specified in the
 `docker-compose` file.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,16 +41,10 @@ and the rest of the script has to wait for Astarte to be ready`,
 var timeoutSeconds int
 
 var serviceToBaseUrl = map[string]string{
-	"Realm Management API": "http://localhost:4000",
-	"Housekeeping API":     "http://localhost:4001",
-	"AppEngine API":        "http://localhost:4002",
-	"Pairing API":          "http://localhost:4003",
-	"Data Updater Plant":   "http://localhost:4004",
-	"Pairing":              "http://localhost:4005",
-	"Realm Management":     "http://localhost:4006",
-	"Trigger Engine":       "http://localhost:4007",
-	"Housekeeping":         "http://localhost:4008",
-	"VerneMQ":              "http://localhost:8888",
+	"Realm Management API": "http://api.astarte.localhost/realmmanagement",
+	"Housekeeping API":     "http://api.astarte.localhost/housekeeping",
+	"AppEngine API":        "http://api.astarte.localhost/appengine",
+	"Pairing API":          "http://api.astarte.localhost/pairing",
 }
 
 func Execute() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "1.0.0-alpha.1"
+var version = "1.1.0"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
The new Astarte docker-compose file exposes Astarte on `http://api.astarte.localhost`. Use the new URLs.